### PR TITLE
fix(linting): resolve warnings being flagged by the linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,7 @@
     "@typescript-eslint/prefer-namespace-keyword": "error",
     "@typescript-eslint/unified-signatures": "error",
     "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     "arrow-body-style": "error",
     "camelcase": [
       "error",

--- a/packages/module/patternfly-docs/generated/extensions/react-console/react.js
+++ b/packages/module/patternfly-docs/generated/extensions/react-console/react.js
@@ -14,8 +14,10 @@ const pageData = {
   "section": "extensions",
   "subsection": "",
   "source": "react",
+  "tabName": null,
   "slug": "/extensions/react-console/react",
   "sourceLink": "https://github.com/patternfly/react-console",
+  "relPath": "packages/module/patternfly-docs/content/extensions/react-console/examples/ReactConsole.md",
   "propComponents": [
     {
       "name": "AccessConsoles",

--- a/packages/module/patternfly-docs/generated/index.js
+++ b/packages/module/patternfly-docs/generated/index.js
@@ -7,6 +7,7 @@ module.exports = {
     section: "extensions",
     subsection: "",
     source: "react",
+    tabName: null,
     Component: () => import(/* webpackChunkName: "extensions/react-console/react/index" */ './extensions/react-console/react')
   }
 };


### PR DESCRIPTION
Closes #25

Disabled `no-explicit-any` as I feel explicit `any` can have value. If you'd rather we just disable `no-exhaustive-deps` as well I'm happy to do that and revert the changes to `Xterm` and `SpiceConsole`.

Alternatively if you think `no-explicit-any` should be enabled we can go that route too.