### PR TITLE
Fix link to virt-manager.org/download

### DIFF
--- a/packages/module/src/components/DesktopViewer/MoreInformationDefaultContent.tsx
+++ b/packages/module/src/components/DesktopViewer/MoreInformationDefaultContent.tsx
@@ -29,7 +29,7 @@ export const MoreInformationDefaultContent: React.FunctionComponent<MoreInformat
       <MoreInformationInstallVariant os="Windows">
         <div>
           Download the MSI from{' '}
-          <a href="https://virt-manager.org/download/" target="_blank" rel="noopener noreferrer">
+          <a href="https://virt-manager.org/download" target="_blank" rel="noopener noreferrer">
             virt-manager.org
           </a>
         </div>

--- a/packages/module/src/components/DesktopViewer/__snapshots__/DesktopViewer.test.tsx.snap
+++ b/packages/module/src/components/DesktopViewer/__snapshots__/DesktopViewer.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`DesktopViewer default MoreInformationContent 1`] = `
           <div>
             Download the MSI from 
             <a
-              href="https://virt-manager.org/download/"
+              href="https://virt-manager.org/download"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -356,7 +356,7 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
                   <div>
                     Download the MSI from 
                     <a
-                      href="https://virt-manager.org/download/"
+                      href="https://virt-manager.org/download"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -683,7 +683,7 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
                   <div>
                     Download the MSI from 
                     <a
-                      href="https://virt-manager.org/download/"
+                      href="https://virt-manager.org/download"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -1091,7 +1091,7 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
                   <div>
                     Download the MSI from 
                     <a
-                      href="https://virt-manager.org/download/"
+                      href="https://virt-manager.org/download"
                       rel="noopener noreferrer"
                       target="_blank"
                     >


### PR DESCRIPTION
Hi

Apparently the link is wrong, if ending with `/` this results in a `404` from `virt-manager.org`.

https://virt-manager.org/download/ => 404
https://virt-manager.org/download => OK