### PR TITLE
update v6 alphas

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -16,14 +16,14 @@ jobs:
           fi
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '18'
       - uses: actions/cache@v2
         id: yarn-cache
         name: Cache npm deps
         with:
           path: |
-           node_modules
-           **/node_modules
+            node_modules
+            **/node_modules
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
@@ -52,14 +52,14 @@ jobs:
           fi
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '18'
       - uses: actions/cache@v2
         id: yarn-cache
         name: Cache npm deps
         with:
           path: |
-           node_modules
-           **/node_modules
+            node_modules
+            **/node_modules
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
@@ -89,15 +89,15 @@ jobs:
           fi
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '18'
       - uses: actions/cache@v2
         id: yarn-cache
         name: Cache npm deps
         with:
           path: |
-           node_modules
-           **/node_modules
-           ~/.cache/Cypress
+            node_modules
+            **/node_modules
+            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
@@ -130,15 +130,15 @@ jobs:
           fi
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '18'
       - uses: actions/cache@v2
         id: yarn-cache
         name: Cache npm deps
         with:
           path: |
-           node_modules
-           **/node_modules
-           ~/.cache/Cypress
+            node_modules
+            **/node_modules
+            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,14 +32,14 @@ jobs:
         if: steps.setup-cache.outputs.cache-hit != 'true'
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '18'
       - uses: actions/cache@v2
         id: yarn-cache
         name: Cache npm deps
         with:
           path: |
-           node_modules
-           **/node_modules
+            node_modules
+            **/node_modules
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '18'
       - uses: actions/cache@v2
         id: yarn-cache
         name: Cache npm deps
         with:
           path: |
-           node_modules
-           **/node_modules
-           ~/.cache/Cypress
+            node_modules
+            **/node_modules
+            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   ],
   "scripts": {
     "build": "yarn workspace @patternfly/react-console build",
+    "build:watch": "npm run build:watch -w @patternfly/react-console",
     "build:docs": "yarn workspace @patternfly/react-console docs:build",
-    "start": "yarn build && concurrently --kill-others \"yarn workspace @patternfly/react-console docs:develop\"",
+    "start": "concurrently --kill-others \"npm run build:watch\" \"npm run docs:develop -w @patternfly/react-console\"",
     "serve:docs": "yarn workspace @patternfly/react-console docs:serve",
     "clean": "yarn workspace @patternfly/react-console clean",
     "lint:js": "node --max-old-space-size=4096 node_modules/.bin/eslint packages --ext js,jsx,ts,tsx --cache",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -6,6 +6,7 @@
   "module": "dist/esm/index.js",
   "scripts": {
     "build": "yarn build:esm && yarn build:cjs",
+    "build:watch": "npm run build:esm -- --watch",
     "build:esm": "tsc --build --verbose ./tsconfig.json",
     "build:cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "clean": "rimraf dist",
@@ -34,8 +35,8 @@
   },
   "dependencies": {
     "@novnc/novnc": "^1.3.0",
-    "@patternfly/react-core": "^6.0.0-alpha.1",
-    "@patternfly/react-styles": "^6.0.0-alpha.1",
+    "@patternfly/react-core": "6.0.0-alpha.50",
+    "@patternfly/react-styles": "6.0.0-alpha.19",
     "@spice-project/spice-html5": "^0.2.1",
     "file-saver": "^1.3.8",
     "xterm": "^4.8.1",
@@ -46,14 +47,13 @@
     "react-dom": "^17 || ^18"
   },
   "devDependencies": {
-    "@patternfly/documentation-framework": "^5.0.15",
-    "@patternfly/patternfly": "^6.0.0-alpha.9",
+    "@patternfly/documentation-framework": "6.0.0-alpha.20",
+    "@patternfly/patternfly": "6.0.0-alpha.117",
     "@patternfly/patternfly-a11y": "^4.3.1",
-    "@patternfly/react-code-editor": "^6.0.0-alpha.1",
-    "@patternfly/react-table": "^6.0.0-alpha.1",
+    "@patternfly/react-code-editor": "6.0.0-alpha.50",
+    "@patternfly/react-table": "6.0.0-alpha.50",
     "rimraf": "^2.6.2",
     "serve": "^14.1.2",
-    "react-monaco-editor": "^0.51.0",
     "monaco-editor": "^0.34.1"
   }
 }

--- a/packages/module/patternfly-docs/generated/extensions/react-console/react.js
+++ b/packages/module/patternfly-docs/generated/extensions/react-console/react.js
@@ -14,6 +14,7 @@ const pageData = {
   "section": "extensions",
   "subsection": "",
   "deprecated": false,
+  "template": false,
   "beta": true,
   "demo": false,
   "newImplementationLink": false,
@@ -362,9 +363,7 @@ pageData.liveContext = {
   SerialConsoleCustom,
   debounce
 };
-pageData.relativeImports = {
-  
-};
+pageData.relativeImports = "import { SerialConsoleCustom } from 'content/extensions/react-console/examples/./SerialConsoleCustom.jsx';"
 pageData.examples = {
   'Basic Usage': props => 
     <Example {...pageData} {...props} thumbnail={srcImportbasicusage} {...{"code":"import React from 'react';\nimport { AccessConsoles, SerialConsole, VncConsole, DesktopViewer } from '@patternfly/react-console';\nimport { SerialConsoleCustom } from './SerialConsoleCustom.jsx';\nimport { debounce } from '@patternfly/react-core';\n\nAccessConsolesVariants = () => {\n  const [status, setStatus] = React.useState('disconnected');\n  const setConnected = React.useRef(debounce(() => setStatus('connected'), 3000)).current;\n  const onConnect = React.useCallback(() => {\n    setStatus('loading');\n    setConnected();\n  }, [setConnected])\n  const onDisconnect = React.useCallback(() => setStatus('disconnected'), [])\n  const ref = React.createRef();\n\n  return (\n    <AccessConsoles preselectedType=\"SerialConsole\">\n      <VncConsole host=\"localhost\" port=\"9090\" encrypt shared />\n      <SerialConsole\n        onConnect={onConnect}\n        status={status}\n        onDisconnect={onDisconnect}\n        onData={data => {\n          ref.current.onDataReceived(data);\n        }}\n        ref={ref}\n      />\n      <SerialConsoleCustom type='Serial Console pty2' />\n      <DesktopViewer spice={{ address: '127.0.0.1', port: '5900' }} vnc={{ address: '127.0.0.1', port: '5901' }} />\n    </AccessConsoles>\n  );\n};","title":"Basic Usage","lang":"js","isFullscreen":true}}>

--- a/packages/module/src/components/AccessConsoles/AccessConsoles.tsx
+++ b/packages/module/src/components/AccessConsoles/AccessConsoles.tsx
@@ -70,7 +70,7 @@ export const AccessConsoles: React.FunctionComponent<AccessConsolesProps> = ({
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       ref={toggleRef}
-      id="pf-v5-c-console__type-selector"
+      id="pf-v6-c-console__type-selector"
       onClick={onToggleClick}
       aria-label="Console type toggle"
       isExpanded={isOpen}

--- a/packages/module/src/components/AccessConsoles/__snapshots__/AccessConsoles.test.tsx.snap
+++ b/packages/module/src/components/AccessConsoles/__snapshots__/AccessConsoles.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AccessConsoles Empty 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console"
+    class="pf-v6-c-console"
   />
 </DocumentFragment>
 `;
@@ -11,7 +11,7 @@ exports[`AccessConsoles Empty 1`] = `
 exports[`AccessConsoles with DesktopViewer 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console"
+    class="pf-v6-c-console"
   />
 </DocumentFragment>
 `;
@@ -19,31 +19,28 @@ exports[`AccessConsoles with DesktopViewer 1`] = `
 exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console"
+    class="pf-v6-c-console"
   >
     <div
-      class="pf-v5-c-console__actions"
+      class="pf-v6-c-console__actions"
     >
       <button
         aria-expanded="false"
         aria-label="Console type toggle"
-        class="pf-v5-c-menu-toggle"
-        id="pf-v5-c-console__type-selector"
+        class="pf-v6-c-menu-toggle"
+        id="pf-v6-c-console__type-selector"
         style="width: 100%;"
         type="button"
       >
         <span
-          class="pf-v5-c-menu-toggle__text"
-        />
-        <span
-          class="pf-v5-c-menu-toggle__controls"
+          class="pf-v6-c-menu-toggle__controls"
         >
           <span
-            class="pf-v5-c-menu-toggle__toggle-icon"
+            class="pf-v6-c-menu-toggle__toggle-icon"
           >
             <svg
               aria-hidden="true"
-              class="pf-v5-svg"
+              class="pf-v6-svg"
               fill="currentColor"
               height="1em"
               role="img"
@@ -65,7 +62,7 @@ exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
 exports[`AccessConsoles with SerialConsole as a single child 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console"
+    class="pf-v6-c-console"
   />
 </DocumentFragment>
 `;
@@ -73,7 +70,7 @@ exports[`AccessConsoles with SerialConsole as a single child 1`] = `
 exports[`AccessConsoles with VncConsole as a single child 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console"
+    class="pf-v6-c-console"
   />
 </DocumentFragment>
 `;
@@ -81,14 +78,14 @@ exports[`AccessConsoles with VncConsole as a single child 1`] = `
 exports[`AccessConsoles with preselected SerialConsole 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console"
+    class="pf-v6-c-console"
   >
     <div
-      class="pf-v5-c-console__actions-serial"
+      class="pf-v6-c-console__actions-serial"
     >
       <button
         aria-disabled="false"
-        class="pf-v5-c-button pf-m-secondary"
+        class="pf-v6-c-button pf-m-secondary"
         data-ouia-component-id="OUIA-Generated-Button-secondary-1"
         data-ouia-component-type="PF5/Button"
         data-ouia-safe="true"
@@ -98,7 +95,7 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
       </button>
       <button
         aria-disabled="false"
-        class="pf-v5-c-button pf-m-secondary"
+        class="pf-v6-c-button pf-m-secondary"
         data-ouia-component-id="OUIA-Generated-Button-secondary-2"
         data-ouia-component-type="PF5/Button"
         data-ouia-safe="true"
@@ -108,30 +105,30 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
       </button>
     </div>
     <div
-      class="pf-v5-c-console__serial"
+      class="pf-v6-c-console__serial"
     >
       <div
-        class="pf-v5-c-empty-state"
+        class="pf-v6-c-empty-state"
       >
         <div
-          class="pf-v5-c-empty-state__content"
+          class="pf-v6-c-empty-state__content"
         >
           <div
-            class="pf-v5-c-empty-state__header"
+            class="pf-v6-c-empty-state__header"
           >
             <div
-              class="pf-v5-c-empty-state__icon"
+              class="pf-v6-c-empty-state__icon"
             >
               <svg
                 aria-hidden="false"
                 aria-label="Contents"
                 aria-valuetext="Loading..."
-                class="pf-v5-c-spinner pf-m-xl"
+                class="pf-v6-c-spinner pf-m-xl"
                 role="progressbar"
                 viewBox="0 0 100 100"
               >
                 <circle
-                  class="pf-v5-c-spinner__path"
+                  class="pf-v6-c-spinner__path"
                   cx="50"
                   cy="50"
                   fill="none"
@@ -139,11 +136,15 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
                 />
               </svg>
             </div>
-          </div>
-          <div
-            class="pf-v5-c-empty-state__body"
-          >
-            Loading ...
+            <div
+              class="pf-v6-c-empty-state__title"
+            >
+              <h1
+                class="pf-v6-c-empty-state__title-text"
+              >
+                Loading ...
+              </h1>
+            </div>
           </div>
         </div>
       </div>
@@ -155,7 +156,7 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
 exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console"
+    class="pf-v6-c-console"
   >
     <p>
       Serial console text

--- a/packages/module/src/components/DesktopViewer/ConnectWithRemoteViewer.tsx
+++ b/packages/module/src/components/DesktopViewer/ConnectWithRemoteViewer.tsx
@@ -97,13 +97,13 @@ export const ConnectWithRemoteViewer: React.FunctionComponent<ConnectWithRemoteV
   // RDP button is rendered only if the protocol is available
   // If none of Spice or VNC is available, the .vv button is disabled (but rendered)
   return (
-    <div className="pf-v5-c-console__remote-viewer">
-      <div className="pf-v5-c-console__remote-viewer-launch">
-        <Button className="pf-v5-c-console__remote-viewer-launch-vv" onClick={onClickVV} isDisabled={!_console}>
+    <div className="pf-v6-c-console__remote-viewer">
+      <div className="pf-v6-c-console__remote-viewer-launch">
+        <Button className="pf-v6-c-console__remote-viewer-launch-vv" onClick={onClickVV} isDisabled={!_console}>
           {textConnectWithRemoteViewer}
         </Button>
         {!!rdp && (
-          <Button onClick={onClickRDP} className="pf-v5-c-console__remote-viewer-launch-rdp">
+          <Button onClick={onClickRDP} className="pf-v6-c-console__remote-viewer-launch-rdp">
             {textConnectWithRDP}
           </Button>
         )}

--- a/packages/module/src/components/DesktopViewer/ManualConnection.tsx
+++ b/packages/module/src/components/DesktopViewer/ManualConnection.tsx
@@ -61,7 +61,7 @@ export const ManualConnection: React.FunctionComponent<ManualConnectionProps> = 
   const rdpAddress = rdp && rdp.address !== address ? rdp.address : null;
 
   return (
-    <div className="pf-v5-c-console__manual-connection">
+    <div className="pf-v6-c-console__manual-connection">
       <Title headingLevel="h2" size="3xl">
         {textManualConnection}
       </Title>

--- a/packages/module/src/components/DesktopViewer/__snapshots__/DesktopViewer.test.tsx.snap
+++ b/packages/module/src/components/DesktopViewer/__snapshots__/DesktopViewer.test.tsx.snap
@@ -15,113 +15,113 @@ exports[`DesktopViewer default MoreInformationContent 1`] = `
      is available for most operating systems. To install it, search for it in GNOME Software or run the following:
   </p>
   <dl
-    class="pf-v5-c-description-list pf-m-horizontal"
+    class="pf-v6-c-description-list pf-m-horizontal"
   >
     <div
-      class="pf-v5-c-description-list__group"
+      class="pf-v6-c-description-list__group"
     >
       <dt
-        class="pf-v5-c-description-list__term"
+        class="pf-v6-c-description-list__term"
       >
         <span
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           RHEL, CentOS
         </span>
       </dt>
       <dd
-        class="pf-v5-c-description-list__description"
+        class="pf-v6-c-description-list__description"
       >
         <div
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           sudo yum install virt-viewer
         </div>
       </dd>
     </div>
     <div
-      class="pf-v5-c-description-list__group"
+      class="pf-v6-c-description-list__group"
     >
       <dt
-        class="pf-v5-c-description-list__term"
+        class="pf-v6-c-description-list__term"
       >
         <span
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           Fedora
         </span>
       </dt>
       <dd
-        class="pf-v5-c-description-list__description"
+        class="pf-v6-c-description-list__description"
       >
         <div
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           sudo dnf install virt-viewer
         </div>
       </dd>
     </div>
     <div
-      class="pf-v5-c-description-list__group"
+      class="pf-v6-c-description-list__group"
     >
       <dt
-        class="pf-v5-c-description-list__term"
+        class="pf-v6-c-description-list__term"
       >
         <span
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           SLE, openSUSE
         </span>
       </dt>
       <dd
-        class="pf-v5-c-description-list__description"
+        class="pf-v6-c-description-list__description"
       >
         <div
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           sudo zypper install virt-viewer
         </div>
       </dd>
     </div>
     <div
-      class="pf-v5-c-description-list__group"
+      class="pf-v6-c-description-list__group"
     >
       <dt
-        class="pf-v5-c-description-list__term"
+        class="pf-v6-c-description-list__term"
       >
         <span
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           Ubuntu, Debian
         </span>
       </dt>
       <dd
-        class="pf-v5-c-description-list__description"
+        class="pf-v6-c-description-list__description"
       >
         <div
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           sudo apt-get install virt-viewer
         </div>
       </dd>
     </div>
     <div
-      class="pf-v5-c-description-list__group"
+      class="pf-v6-c-description-list__group"
     >
       <dt
-        class="pf-v5-c-description-list__term"
+        class="pf-v6-c-description-list__term"
       >
         <span
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           Windows
         </span>
       </dt>
       <dd
-        class="pf-v5-c-description-list__description"
+        class="pf-v6-c-description-list__description"
       >
         <div
-          class="pf-v5-c-description-list__text"
+          class="pf-v6-c-description-list__text"
         >
           <div>
             Download the MSI from 
@@ -143,17 +143,17 @@ exports[`DesktopViewer default MoreInformationContent 1`] = `
 exports[`DesktopViewer empty 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__desktop-viewer"
+    class="pf-v6-c-console__desktop-viewer"
   >
     <div
-      class="pf-v5-c-console__remote-viewer"
+      class="pf-v6-c-console__remote-viewer"
     >
       <div
-        class="pf-v5-c-console__remote-viewer-launch"
+        class="pf-v6-c-console__remote-viewer-launch"
       >
         <button
           aria-disabled="true"
-          class="pf-v5-c-button pf-m-primary pf-m-disabled pf-v5-c-console__remote-viewer-launch-vv"
+          class="pf-v6-c-button pf-m-primary pf-m-disabled pf-v6-c-console__remote-viewer-launch-vv"
           data-ouia-component-id="OUIA-Generated-Button-primary-1"
           data-ouia-component-type="PF5/Button"
           data-ouia-safe="true"
@@ -165,10 +165,10 @@ exports[`DesktopViewer empty 1`] = `
       </div>
     </div>
     <div
-      class="pf-v5-c-console__manual-connection"
+      class="pf-v6-c-console__manual-connection"
     >
       <h2
-        class="pf-v5-c-title pf-m-3xl"
+        class="pf-v6-c-title pf-m-3xl"
         data-ouia-component-id="OUIA-Generated-Title-1"
         data-ouia-component-type="PF5/Title"
         data-ouia-safe="true"
@@ -179,7 +179,7 @@ exports[`DesktopViewer empty 1`] = `
         No connection available.
       </p>
       <dl
-        class="pf-v5-c-description-list"
+        class="pf-v6-c-description-list"
       />
     </div>
   </div>
@@ -189,17 +189,17 @@ exports[`DesktopViewer empty 1`] = `
 exports[`DesktopViewer with Spice and VNC 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__desktop-viewer"
+    class="pf-v6-c-console__desktop-viewer"
   >
     <div
-      class="pf-v5-c-console__remote-viewer"
+      class="pf-v6-c-console__remote-viewer"
     >
       <div
-        class="pf-v5-c-console__remote-viewer-launch"
+        class="pf-v6-c-console__remote-viewer-launch"
       >
         <button
           aria-disabled="false"
-          class="pf-v5-c-button pf-m-primary pf-v5-c-console__remote-viewer-launch-vv"
+          class="pf-v6-c-button pf-m-primary pf-v6-c-console__remote-viewer-launch-vv"
           data-ouia-component-id="OUIA-Generated-Button-primary-2"
           data-ouia-component-type="PF5/Button"
           data-ouia-safe="true"
@@ -209,21 +209,21 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
         </button>
       </div>
       <div
-        class="pf-v5-c-expandable-section"
+        class="pf-v6-c-expandable-section"
       >
         <button
           aria-controls="remote-viewer-details-content"
           aria-expanded="false"
-          class="pf-v5-c-expandable-section__toggle"
+          class="pf-v6-c-expandable-section__toggle"
           id="remote-viewer-details-toggle"
           type="button"
         >
           <span
-            class="pf-v5-c-expandable-section__toggle-icon"
+            class="pf-v6-c-expandable-section__toggle-icon"
           >
             <svg
               aria-hidden="true"
-              class="pf-v5-svg"
+              class="pf-v6-svg"
               fill="currentColor"
               height="1em"
               role="img"
@@ -236,126 +236,126 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
             </svg>
           </span>
           <span
-            class="pf-v5-c-expandable-section__toggle-text"
+            class="pf-v6-c-expandable-section__toggle-text"
           >
             Remote Viewer Details
           </span>
         </button>
         <div
           aria-labelledby="remote-viewer-details-toggle"
-          class="pf-v5-c-expandable-section__content"
+          class="pf-v6-c-expandable-section__content"
           hidden=""
           id="remote-viewer-details-content"
           role="region"
         >
           <dl
-            class="pf-v5-c-description-list pf-m-horizontal"
+            class="pf-v6-c-description-list pf-m-horizontal"
           >
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   RHEL, CentOS
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo yum install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Fedora
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo dnf install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   SLE, openSUSE
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo zypper install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Ubuntu, Debian
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo apt-get install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Windows
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   <div>
                     Download the MSI from 
@@ -375,10 +375,10 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
       </div>
     </div>
     <div
-      class="pf-v5-c-console__manual-connection"
+      class="pf-v6-c-console__manual-connection"
     >
       <h2
-        class="pf-v5-c-title pf-m-3xl"
+        class="pf-v6-c-title pf-m-3xl"
         data-ouia-component-id="OUIA-Generated-Title-2"
         data-ouia-component-type="PF5/Title"
         data-ouia-safe="true"
@@ -389,113 +389,113 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
         Connect with any viewer application for following protocols
       </p>
       <dl
-        class="pf-v5-c-description-list"
+        class="pf-v6-c-description-list"
       >
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               Address
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               my.host.com
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               SPICE Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5900
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               SPICE TLS Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5901
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               VNC Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5902
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               VNC TLS Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5903
             </div>
@@ -510,17 +510,17 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
 exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__desktop-viewer"
+    class="pf-v6-c-console__desktop-viewer"
   >
     <div
-      class="pf-v5-c-console__remote-viewer"
+      class="pf-v6-c-console__remote-viewer"
     >
       <div
-        class="pf-v5-c-console__remote-viewer-launch"
+        class="pf-v6-c-console__remote-viewer-launch"
       >
         <button
           aria-disabled="false"
-          class="pf-v5-c-button pf-m-primary pf-v5-c-console__remote-viewer-launch-vv"
+          class="pf-v6-c-button pf-m-primary pf-v6-c-console__remote-viewer-launch-vv"
           data-ouia-component-id="OUIA-Generated-Button-primary-5"
           data-ouia-component-type="PF5/Button"
           data-ouia-safe="true"
@@ -530,7 +530,7 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
         </button>
         <button
           aria-disabled="false"
-          class="pf-v5-c-button pf-m-primary pf-v5-c-console__remote-viewer-launch-rdp"
+          class="pf-v6-c-button pf-m-primary pf-v6-c-console__remote-viewer-launch-rdp"
           data-ouia-component-id="OUIA-Generated-Button-primary-6"
           data-ouia-component-type="PF5/Button"
           data-ouia-safe="true"
@@ -540,21 +540,21 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
         </button>
       </div>
       <div
-        class="pf-v5-c-expandable-section"
+        class="pf-v6-c-expandable-section"
       >
         <button
           aria-controls="remote-viewer-details-content"
           aria-expanded="false"
-          class="pf-v5-c-expandable-section__toggle"
+          class="pf-v6-c-expandable-section__toggle"
           id="remote-viewer-details-toggle"
           type="button"
         >
           <span
-            class="pf-v5-c-expandable-section__toggle-icon"
+            class="pf-v6-c-expandable-section__toggle-icon"
           >
             <svg
               aria-hidden="true"
-              class="pf-v5-svg"
+              class="pf-v6-svg"
               fill="currentColor"
               height="1em"
               role="img"
@@ -567,126 +567,126 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
             </svg>
           </span>
           <span
-            class="pf-v5-c-expandable-section__toggle-text"
+            class="pf-v6-c-expandable-section__toggle-text"
           >
             Remote Viewer Details
           </span>
         </button>
         <div
           aria-labelledby="remote-viewer-details-toggle"
-          class="pf-v5-c-expandable-section__content"
+          class="pf-v6-c-expandable-section__content"
           hidden=""
           id="remote-viewer-details-content"
           role="region"
         >
           <dl
-            class="pf-v5-c-description-list pf-m-horizontal"
+            class="pf-v6-c-description-list pf-m-horizontal"
           >
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   RHEL, CentOS
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo yum install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Fedora
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo dnf install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   SLE, openSUSE
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo zypper install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Ubuntu, Debian
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo apt-get install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Windows
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   <div>
                     Download the MSI from 
@@ -705,21 +705,21 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
         </div>
       </div>
       <div
-        class="pf-v5-c-expandable-section"
+        class="pf-v6-c-expandable-section"
       >
         <button
           aria-controls="remote-desktop-details-content"
           aria-expanded="false"
-          class="pf-v5-c-expandable-section__toggle"
+          class="pf-v6-c-expandable-section__toggle"
           id="remote-desktop-details-toggle"
           type="button"
         >
           <span
-            class="pf-v5-c-expandable-section__toggle-icon"
+            class="pf-v6-c-expandable-section__toggle-icon"
           >
             <svg
               aria-hidden="true"
-              class="pf-v5-svg"
+              class="pf-v6-svg"
               fill="currentColor"
               height="1em"
               role="img"
@@ -732,14 +732,14 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
             </svg>
           </span>
           <span
-            class="pf-v5-c-expandable-section__toggle-text"
+            class="pf-v6-c-expandable-section__toggle-text"
           >
             Remote Desktop Details
           </span>
         </button>
         <div
           aria-labelledby="remote-desktop-details-toggle"
-          class="pf-v5-c-expandable-section__content"
+          class="pf-v6-c-expandable-section__content"
           hidden=""
           id="remote-desktop-details-content"
           role="region"
@@ -747,10 +747,10 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
       </div>
     </div>
     <div
-      class="pf-v5-c-console__manual-connection"
+      class="pf-v6-c-console__manual-connection"
     >
       <h2
-        class="pf-v5-c-title pf-m-3xl"
+        class="pf-v6-c-title pf-m-3xl"
         data-ouia-component-id="OUIA-Generated-Title-4"
         data-ouia-component-type="PF5/Title"
         data-ouia-safe="true"
@@ -761,157 +761,157 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
         Connect with any viewer application for following protocols
       </p>
       <dl
-        class="pf-v5-c-description-list"
+        class="pf-v6-c-description-list"
       >
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               Address
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               my.host.com
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               RDP Address
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               my.differenthost.com
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               SPICE Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5900
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               SPICE TLS Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5901
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               VNC Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5902
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               VNC TLS Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5903
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               RDP Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               1234
             </div>
@@ -926,17 +926,17 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
 exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__desktop-viewer"
+    class="pf-v6-c-console__desktop-viewer"
   >
     <div
-      class="pf-v5-c-console__remote-viewer"
+      class="pf-v6-c-console__remote-viewer"
     >
       <div
-        class="pf-v5-c-console__remote-viewer-launch"
+        class="pf-v6-c-console__remote-viewer-launch"
       >
         <button
           aria-disabled="false"
-          class="pf-v5-c-button pf-m-primary pf-v5-c-console__remote-viewer-launch-vv"
+          class="pf-v6-c-button pf-m-primary pf-v6-c-console__remote-viewer-launch-vv"
           data-ouia-component-id="OUIA-Generated-Button-primary-3"
           data-ouia-component-type="PF5/Button"
           data-ouia-safe="true"
@@ -946,7 +946,7 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
         </button>
         <button
           aria-disabled="false"
-          class="pf-v5-c-button pf-m-primary pf-v5-c-console__remote-viewer-launch-rdp"
+          class="pf-v6-c-button pf-m-primary pf-v6-c-console__remote-viewer-launch-rdp"
           data-ouia-component-id="OUIA-Generated-Button-primary-4"
           data-ouia-component-type="PF5/Button"
           data-ouia-safe="true"
@@ -956,21 +956,21 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
         </button>
       </div>
       <div
-        class="pf-v5-c-expandable-section"
+        class="pf-v6-c-expandable-section"
       >
         <button
           aria-controls="remote-viewer-details-content"
           aria-expanded="false"
-          class="pf-v5-c-expandable-section__toggle"
+          class="pf-v6-c-expandable-section__toggle"
           id="remote-viewer-details-toggle"
           type="button"
         >
           <span
-            class="pf-v5-c-expandable-section__toggle-icon"
+            class="pf-v6-c-expandable-section__toggle-icon"
           >
             <svg
               aria-hidden="true"
-              class="pf-v5-svg"
+              class="pf-v6-svg"
               fill="currentColor"
               height="1em"
               role="img"
@@ -983,126 +983,126 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
             </svg>
           </span>
           <span
-            class="pf-v5-c-expandable-section__toggle-text"
+            class="pf-v6-c-expandable-section__toggle-text"
           >
             Remote Viewer Details
           </span>
         </button>
         <div
           aria-labelledby="remote-viewer-details-toggle"
-          class="pf-v5-c-expandable-section__content"
+          class="pf-v6-c-expandable-section__content"
           hidden=""
           id="remote-viewer-details-content"
           role="region"
         >
           <dl
-            class="pf-v5-c-description-list pf-m-horizontal"
+            class="pf-v6-c-description-list pf-m-horizontal"
           >
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   RHEL, CentOS
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo yum install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Fedora
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo dnf install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   SLE, openSUSE
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo zypper install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Ubuntu, Debian
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   sudo apt-get install virt-viewer
                 </div>
               </dd>
             </div>
             <div
-              class="pf-v5-c-description-list__group"
+              class="pf-v6-c-description-list__group"
             >
               <dt
-                class="pf-v5-c-description-list__term"
+                class="pf-v6-c-description-list__term"
               >
                 <span
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   Windows
                 </span>
               </dt>
               <dd
-                class="pf-v5-c-description-list__description"
+                class="pf-v6-c-description-list__description"
               >
                 <div
-                  class="pf-v5-c-description-list__text"
+                  class="pf-v6-c-description-list__text"
                 >
                   <div>
                     Download the MSI from 
@@ -1121,21 +1121,21 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
         </div>
       </div>
       <div
-        class="pf-v5-c-expandable-section"
+        class="pf-v6-c-expandable-section"
       >
         <button
           aria-controls="remote-desktop-details-content"
           aria-expanded="false"
-          class="pf-v5-c-expandable-section__toggle"
+          class="pf-v6-c-expandable-section__toggle"
           id="remote-desktop-details-toggle"
           type="button"
         >
           <span
-            class="pf-v5-c-expandable-section__toggle-icon"
+            class="pf-v6-c-expandable-section__toggle-icon"
           >
             <svg
               aria-hidden="true"
-              class="pf-v5-svg"
+              class="pf-v6-svg"
               fill="currentColor"
               height="1em"
               role="img"
@@ -1148,14 +1148,14 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
             </svg>
           </span>
           <span
-            class="pf-v5-c-expandable-section__toggle-text"
+            class="pf-v6-c-expandable-section__toggle-text"
           >
             Remote Desktop Details
           </span>
         </button>
         <div
           aria-labelledby="remote-desktop-details-toggle"
-          class="pf-v5-c-expandable-section__content"
+          class="pf-v6-c-expandable-section__content"
           hidden=""
           id="remote-desktop-details-content"
           role="region"
@@ -1163,10 +1163,10 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
       </div>
     </div>
     <div
-      class="pf-v5-c-console__manual-connection"
+      class="pf-v6-c-console__manual-connection"
     >
       <h2
-        class="pf-v5-c-title pf-m-3xl"
+        class="pf-v6-c-title pf-m-3xl"
         data-ouia-component-id="OUIA-Generated-Title-3"
         data-ouia-component-type="PF5/Title"
         data-ouia-safe="true"
@@ -1177,135 +1177,135 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
         Connect with any viewer application for following protocols
       </p>
       <dl
-        class="pf-v5-c-description-list"
+        class="pf-v6-c-description-list"
       >
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               Address
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               my.host.com
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               SPICE Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5900
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               SPICE TLS Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5901
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               VNC Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5902
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               VNC TLS Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               5903
             </div>
           </dd>
         </div>
         <div
-          class="pf-v5-c-description-list__group"
+          class="pf-v6-c-description-list__group"
         >
           <dt
-            class="pf-v5-c-description-list__term"
+            class="pf-v6-c-description-list__term"
           >
             <span
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               RDP Port
             </span>
           </dt>
           <dd
-            class="pf-v5-c-description-list__description"
+            class="pf-v6-c-description-list__description"
           >
             <div
-              class="pf-v5-c-description-list__text"
+              class="pf-v6-c-description-list__text"
             >
               3389
             </div>

--- a/packages/module/src/components/SerialConsole/SerialConsole.tsx
+++ b/packages/module/src/components/SerialConsole/SerialConsole.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 
 import { css } from '@patternfly/react-styles';
-import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Spinner,
-  EmptyStateHeader,
-  EmptyStateFooter
-} from '@patternfly/react-core';
+import { Button, EmptyState, Spinner, EmptyStateFooter } from '@patternfly/react-core';
 
 import { XTerm, XTermProps } from './XTerm';
 import { SerialConsoleActions } from './SerialConsoleActions';
@@ -115,8 +107,7 @@ const SerialConsoleBase: React.FunctionComponent<SerialConsoleProps> = ({
       break;
     case DISCONNECTED:
       terminal = (
-        <EmptyState>
-          <EmptyStateBody>{textDisconnected}</EmptyStateBody>
+        <EmptyState titleText={textDisconnected}>
           <EmptyStateFooter>
             <Button onClick={onConnectClick}>{textConnect}</Button>
           </EmptyStateFooter>
@@ -125,12 +116,7 @@ const SerialConsoleBase: React.FunctionComponent<SerialConsoleProps> = ({
       break;
     case LOADING:
     default:
-      terminal = (
-        <EmptyState>
-          <EmptyStateHeader icon={<EmptyStateIcon icon={Spinner} />} />
-          <EmptyStateBody>{textLoading}</EmptyStateBody>
-        </EmptyState>
-      );
+      terminal = <EmptyState icon={Spinner} titleText={textLoading}></EmptyState>;
       break;
   }
 

--- a/packages/module/src/components/SerialConsole/XTerm.tsx
+++ b/packages/module/src/components/SerialConsole/XTerm.tsx
@@ -71,7 +71,6 @@ export const XTerm: React.FunctionComponent<XTermProps> = ({
     return '';
   }, []);
 
-
   const onFocusIn = () => {
     window.addEventListener('beforeunload', onBeforeUnload);
   };
@@ -131,6 +130,6 @@ export const XTerm: React.FunctionComponent<XTermProps> = ({
 
   // ensure react never reuses this div by keying it with the terminal widget
   // Workaround for xtermjs/xterm.js#3172
-  return <div ref={ref} className="pf-v5-c-console__xterm" role="list" onFocus={onFocusIn} onBlur={onFocusOut} />;
+  return <div ref={ref} className="pf-v6-c-console__xterm" role="list" onFocus={onFocusIn} onBlur={onFocusOut} />;
 };
 XTerm.displayName = 'XTerm';

--- a/packages/module/src/components/SerialConsole/__snapshots__/SerialConsole.test.tsx.snap
+++ b/packages/module/src/components/SerialConsole/__snapshots__/SerialConsole.test.tsx.snap
@@ -3,25 +3,33 @@
 exports[`SerialConsole in the DISCONNECTED state 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__serial"
+    class="pf-v6-c-console__serial"
   >
     <div
-      class="pf-v5-c-empty-state"
+      class="pf-v6-c-empty-state"
     >
       <div
-        class="pf-v5-c-empty-state__content"
+        class="pf-v6-c-empty-state__content"
       >
         <div
-          class="pf-v5-c-empty-state__body"
+          class="pf-v6-c-empty-state__header"
         >
-          My text for Disconnected
+          <div
+            class="pf-v6-c-empty-state__title"
+          >
+            <h1
+              class="pf-v6-c-empty-state__title-text"
+            >
+              My text for Disconnected
+            </h1>
+          </div>
         </div>
         <div
-          class="pf-v5-c-empty-state__footer"
+          class="pf-v6-c-empty-state__footer"
         >
           <button
             aria-disabled="false"
-            class="pf-v5-c-button pf-m-primary"
+            class="pf-v6-c-button pf-m-primary"
             data-ouia-component-id="OUIA-Generated-Button-primary-1"
             data-ouia-component-type="PF5/Button"
             data-ouia-safe="true"
@@ -39,11 +47,11 @@ exports[`SerialConsole in the DISCONNECTED state 1`] = `
 exports[`SerialConsole in the LOADING state 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__actions-serial"
+    class="pf-v6-c-console__actions-serial"
   >
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-1"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -53,7 +61,7 @@ exports[`SerialConsole in the LOADING state 1`] = `
     </button>
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-2"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -63,30 +71,30 @@ exports[`SerialConsole in the LOADING state 1`] = `
     </button>
   </div>
   <div
-    class="pf-v5-c-console__serial"
+    class="pf-v6-c-console__serial"
   >
     <div
-      class="pf-v5-c-empty-state"
+      class="pf-v6-c-empty-state"
     >
       <div
-        class="pf-v5-c-empty-state__content"
+        class="pf-v6-c-empty-state__content"
       >
         <div
-          class="pf-v5-c-empty-state__header"
+          class="pf-v6-c-empty-state__header"
         >
           <div
-            class="pf-v5-c-empty-state__icon"
+            class="pf-v6-c-empty-state__icon"
           >
             <svg
               aria-hidden="false"
               aria-label="Contents"
               aria-valuetext="Loading..."
-              class="pf-v5-c-spinner pf-m-xl"
+              class="pf-v6-c-spinner pf-m-xl"
               role="progressbar"
               viewBox="0 0 100 100"
             >
               <circle
-                class="pf-v5-c-spinner__path"
+                class="pf-v6-c-spinner__path"
                 cx="50"
                 cy="50"
                 fill="none"
@@ -94,11 +102,15 @@ exports[`SerialConsole in the LOADING state 1`] = `
               />
             </svg>
           </div>
-        </div>
-        <div
-          class="pf-v5-c-empty-state__body"
-        >
-          My text for Loading
+          <div
+            class="pf-v6-c-empty-state__title"
+          >
+            <h1
+              class="pf-v6-c-empty-state__title-text"
+            >
+              My text for Loading
+            </h1>
+          </div>
         </div>
       </div>
     </div>
@@ -109,11 +121,11 @@ exports[`SerialConsole in the LOADING state 1`] = `
 exports[`SerialConsole with CONNECTED state renders 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__actions-serial"
+    class="pf-v6-c-console__actions-serial"
   >
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-3"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -123,7 +135,7 @@ exports[`SerialConsole with CONNECTED state renders 1`] = `
     </button>
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-4"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -133,10 +145,10 @@ exports[`SerialConsole with CONNECTED state renders 1`] = `
     </button>
   </div>
   <div
-    class="pf-v5-c-console__serial"
+    class="pf-v6-c-console__serial"
   >
     <div
-      class="pf-v5-c-console__xterm"
+      class="pf-v6-c-console__xterm"
       role="list"
     >
       <div

--- a/packages/module/src/components/SerialConsole/__snapshots__/SerialConsoleActions.test.tsx.snap
+++ b/packages/module/src/components/SerialConsole/__snapshots__/SerialConsoleActions.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Render SerialConsoleActions 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__actions-serial"
+    class="pf-v6-c-console__actions-serial"
   >
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-1"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -17,7 +17,7 @@ exports[`Render SerialConsoleActions 1`] = `
     </button>
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-2"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -32,11 +32,11 @@ exports[`Render SerialConsoleActions 1`] = `
 exports[`Render SerialConsoleActions with custom texts 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__actions-serial"
+    class="pf-v6-c-console__actions-serial"
   >
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-3"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -46,7 +46,7 @@ exports[`Render SerialConsoleActions with custom texts 1`] = `
     </button>
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-4"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"

--- a/packages/module/src/components/SerialConsole/__snapshots__/XTerm.test.tsx.snap
+++ b/packages/module/src/components/SerialConsole/__snapshots__/XTerm.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`XTerm Render empty XTerm component 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__xterm"
+    class="pf-v6-c-console__xterm"
     role="list"
   >
     <div

--- a/packages/module/src/components/VncConsole/VncActions.tsx
+++ b/packages/module/src/components/VncConsole/VncActions.tsx
@@ -37,7 +37,7 @@ export const VncActions: React.FunctionComponent<VncActionProps> = ({
     <div className={css(styles.consoleActionsVnc)}>
       {additionalButtons}
       <Dropdown
-        id="pf-v5-c-console__send-shortcut"
+        id="pf-v6-c-console__send-shortcut"
         isOpen={isOpen}
         onSelect={onSelect}
         onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/module/src/components/VncConsole/VncConsole.tsx
+++ b/packages/module/src/components/VncConsole/VncConsole.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 
 import { css } from '@patternfly/react-styles';
-import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Spinner,
-  EmptyStateHeader,
-  EmptyStateFooter
-} from '@patternfly/react-core';
+import { Button, EmptyState, Spinner, EmptyStateFooter } from '@patternfly/react-core';
 
 import { initLogging } from '@novnc/novnc/core/util/logging';
 /** Has bad types. https://github.com/larryprice/novnc-core/issues/5 */
@@ -226,8 +218,7 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
       break;
     case DISCONNECTED:
       emptyState = (
-        <EmptyState>
-          <EmptyStateBody>{textDisconnected}</EmptyStateBody>
+        <EmptyState titleText={textDisconnected}>
           <EmptyStateFooter>
             <Button variant="primary" onClick={connect}>
               {textConnect}
@@ -238,12 +229,7 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
       break;
     case CONNECTING:
     default:
-      emptyState = (
-        <EmptyState>
-          <EmptyStateHeader icon={<EmptyStateIcon icon={Spinner} />} />
-          <EmptyStateBody>{textConnecting}</EmptyStateBody>
-        </EmptyState>
-      );
+      emptyState = <EmptyState icon={Spinner} titleText={textConnecting}></EmptyState>;
   }
 
   return (

--- a/packages/module/src/components/VncConsole/__snapshots__/VncActions.test.tsx.snap
+++ b/packages/module/src/components/VncConsole/__snapshots__/VncActions.test.tsx.snap
@@ -3,27 +3,27 @@
 exports[`VncActions VncActions renders correctly component hierarchy 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__actions-vnc"
+    class="pf-v6-c-console__actions-vnc"
   >
     <button
       aria-expanded="false"
-      class="pf-v5-c-menu-toggle"
+      class="pf-v6-c-menu-toggle"
       type="button"
     >
       <span
-        class="pf-v5-c-menu-toggle__text"
+        class="pf-v6-c-menu-toggle__text"
       >
         My Send Shortcut description
       </span>
       <span
-        class="pf-v5-c-menu-toggle__controls"
+        class="pf-v6-c-menu-toggle__controls"
       >
         <span
-          class="pf-v5-c-menu-toggle__toggle-icon"
+          class="pf-v6-c-menu-toggle__toggle-icon"
         >
           <svg
             aria-hidden="true"
-            class="pf-v5-svg"
+            class="pf-v6-svg"
             fill="currentColor"
             height="1em"
             role="img"
@@ -39,7 +39,7 @@ exports[`VncActions VncActions renders correctly component hierarchy 1`] = `
     </button>
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-2"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -54,27 +54,27 @@ exports[`VncActions VncActions renders correctly component hierarchy 1`] = `
 exports[`VncActions VncActions renders correctly html 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__actions-vnc"
+    class="pf-v6-c-console__actions-vnc"
   >
     <button
       aria-expanded="false"
-      class="pf-v5-c-menu-toggle"
+      class="pf-v6-c-menu-toggle"
       type="button"
     >
       <span
-        class="pf-v5-c-menu-toggle__text"
+        class="pf-v6-c-menu-toggle__text"
       >
         My Send Shortcut description
       </span>
       <span
-        class="pf-v5-c-menu-toggle__controls"
+        class="pf-v6-c-menu-toggle__controls"
       >
         <span
-          class="pf-v5-c-menu-toggle__toggle-icon"
+          class="pf-v6-c-menu-toggle__toggle-icon"
         >
           <svg
             aria-hidden="true"
-            class="pf-v5-svg"
+            class="pf-v6-svg"
             fill="currentColor"
             height="1em"
             role="img"
@@ -90,7 +90,7 @@ exports[`VncActions VncActions renders correctly html 1`] = `
     </button>
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-3"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"
@@ -105,27 +105,27 @@ exports[`VncActions VncActions renders correctly html 1`] = `
 exports[`VncActions placeholder render test 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__actions-vnc"
+    class="pf-v6-c-console__actions-vnc"
   >
     <button
       aria-expanded="false"
-      class="pf-v5-c-menu-toggle"
+      class="pf-v6-c-menu-toggle"
       type="button"
     >
       <span
-        class="pf-v5-c-menu-toggle__text"
+        class="pf-v6-c-menu-toggle__text"
       >
         Send Key
       </span>
       <span
-        class="pf-v5-c-menu-toggle__controls"
+        class="pf-v6-c-menu-toggle__controls"
       >
         <span
-          class="pf-v5-c-menu-toggle__toggle-icon"
+          class="pf-v6-c-menu-toggle__toggle-icon"
         >
           <svg
             aria-hidden="true"
-            class="pf-v5-svg"
+            class="pf-v6-svg"
             fill="currentColor"
             height="1em"
             role="img"
@@ -141,7 +141,7 @@ exports[`VncActions placeholder render test 1`] = `
     </button>
     <button
       aria-disabled="false"
-      class="pf-v5-c-button pf-m-secondary"
+      class="pf-v6-c-button pf-m-secondary"
       data-ouia-component-id="OUIA-Generated-Button-secondary-1"
       data-ouia-component-type="PF5/Button"
       data-ouia-safe="true"

--- a/packages/module/src/components/VncConsole/__snapshots__/VncConsole.test.tsx.snap
+++ b/packages/module/src/components/VncConsole/__snapshots__/VncConsole.test.tsx.snap
@@ -3,31 +3,31 @@
 exports[`placeholder render test 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-console__vnc"
+    class="pf-v6-c-console__vnc"
   >
     <div>
       <div
-        class="pf-v5-c-empty-state"
+        class="pf-v6-c-empty-state"
       >
         <div
-          class="pf-v5-c-empty-state__content"
+          class="pf-v6-c-empty-state__content"
         >
           <div
-            class="pf-v5-c-empty-state__header"
+            class="pf-v6-c-empty-state__header"
           >
             <div
-              class="pf-v5-c-empty-state__icon"
+              class="pf-v6-c-empty-state__icon"
             >
               <svg
                 aria-hidden="false"
                 aria-label="Contents"
                 aria-valuetext="Loading..."
-                class="pf-v5-c-spinner pf-m-xl"
+                class="pf-v6-c-spinner pf-m-xl"
                 role="progressbar"
                 viewBox="0 0 100 100"
               >
                 <circle
-                  class="pf-v5-c-spinner__path"
+                  class="pf-v6-c-spinner__path"
                   cx="50"
                   cy="50"
                   fill="none"
@@ -35,11 +35,15 @@ exports[`placeholder render test 1`] = `
                 />
               </svg>
             </div>
-          </div>
-          <div
-            class="pf-v5-c-empty-state__body"
-          >
-            Connecting
+            <div
+              class="pf-v6-c-empty-state__title"
+            >
+              <h1
+                class="pf-v6-c-empty-state__title-text"
+              >
+                Connecting
+              </h1>
+            </div>
           </div>
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,6 +1549,20 @@
   resolved "https://registry.npmjs.org/@mdx-js/util/-/util-2.0.0-next.8.tgz"
   integrity sha512-T0BcXmNzEunFkuxrO8BFw44htvTPuAoKbLvTG41otyZBDV1Rs+JMddcUuaP5vXpTWtgD3grhcrPEwyx88RUumQ==
 
+"@monaco-editor/loader@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.4.0.tgz#f08227057331ec890fa1e903912a5b711a2ad558"
+  integrity sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==
+  dependencies:
+    state-local "^1.0.6"
+
+"@monaco-editor/react@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.6.0.tgz#bcc68671e358a21c3814566b865a54b191e24119"
+  integrity sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==
+  dependencies:
+    "@monaco-editor/loader" "^1.4.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -1575,10 +1589,10 @@
   resolved "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.3.0.tgz"
   integrity sha512-tR87mY5ADtaELadmZfW937JO/p8fRdz3wkPoqwhqB/vY1XnTQeLSWwkp4yMlr4iIDY0iCficfzFYX5EHMh4MHw==
 
-"@patternfly/ast-helpers@^0.4.57":
-  version "0.4.79"
-  resolved "https://registry.npmjs.org/@patternfly/ast-helpers/-/ast-helpers-0.4.79.tgz"
-  integrity sha512-Nn2Uut7Z1nQwDr5LAf1bns6yCFQFQWwXE2I1Ucvbk6s2Gl2X/85VGvww8FVO+YiW/plLZMLBFRPJMP4fs2N8Cg==
+"@patternfly/ast-helpers@^1.4.0-alpha.9":
+  version "1.4.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@patternfly/ast-helpers/-/ast-helpers-1.4.0-alpha.9.tgz#de5135ac5906d16b3a73a137ab8b5efd460c78f0"
+  integrity sha512-kq4vfrDPr6NfuBbIvqgGKRCl+WASWAUgf5+mF4rD0Db/00kJ3kdx5P70a14YK5H1R0Tcf7m4v+u/NLMCESR17w==
   dependencies:
     acorn "^8.4.1"
     acorn-class-fields "^1.0.0"
@@ -1586,10 +1600,10 @@
     acorn-static-class-features "^1.0.0"
     astring "^1.7.5"
 
-"@patternfly/documentation-framework@^5.0.15":
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-5.0.15.tgz#56e6608de10a95a92787686e5db1eb3ff7c09b89"
-  integrity sha512-3r9fqPeAKY8GeJM6m7VPyPsiggxhyDbbWTo2/4T4NoNisVPpFXi0AzUaTpvJU2KcBx5pSot1mb84V3f8DHzWXg==
+"@patternfly/documentation-framework@6.0.0-alpha.20":
+  version "6.0.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-6.0.0-alpha.20.tgz#bdd66d2647b39d1422edeccfb51ff2e6e18d8191"
+  integrity sha512-OVhzLMjSWFqmzPHFiWkN9EooYVF5xgy1R9CByr8+TOI8lrXvBs4ACkErf3LCHwqNkzsbuFB26M0NSqK8OQZq5A==
   dependencies:
     "@babel/core" "7.18.2"
     "@babel/plugin-proposal-class-properties" "7.17.12"
@@ -1599,7 +1613,7 @@
     "@babel/plugin-transform-react-jsx" "7.17.12"
     "@babel/preset-env" "7.18.2"
     "@mdx-js/util" "1.6.16"
-    "@patternfly/ast-helpers" "^0.4.57"
+    "@patternfly/ast-helpers" "^1.4.0-alpha.9"
     "@reach/router" "npm:@gatsbyjs/reach-router@1.3.9"
     autoprefixer "9.8.6"
     babel-loader "9.1.2"
@@ -1615,7 +1629,7 @@
     file-loader "6.2.0"
     file-saver "1.3.8"
     fs-extra "9.0.1"
-    glob "8.0.3"
+    glob "9.0.0"
     handlebars "4.7.7"
     hast-to-hyperscript "9.0.0"
     hast-util-to-text "2.0.0"
@@ -1625,18 +1639,15 @@
     mdast-util-to-hast "9.1.1"
     mdurl "1.0.1"
     mini-css-extract-plugin "2.7.5"
-    monaco-editor "0.34.1"
-    monaco-editor-webpack-plugin "7.0.1"
     null-loader "4.0.1"
     parse-entities "2.0.0"
     path-browserify "1.0.1"
-    postcss "7.0.32"
+    postcss "8.4.32"
     postcss-loader "7.1.0"
     process "^0.11.10"
-    puppeteer "14.3.0"
+    puppeteer "19.11.1"
     puppeteer-cluster "0.23.0"
     react-docgen "5.3.1"
-    react-monaco-editor "^0.51.0"
     react-ssr-prepass "1.5.0"
     remark-footnotes "1.0.0"
     remark-frontmatter "2.0.0"
@@ -1645,10 +1656,10 @@
     remark-parse "8.0.3"
     remark-squeeze-paragraphs "4.0.0"
     responsive-loader "3.1.2"
-    sharp "0.30.6"
+    sharp "0.32.6"
     style-to-object "0.3.0"
     to-vfile "6.1.0"
-    typedoc "0.22.X"
+    typedoc "0.23.0"
     typescript "4.3.5"
     unified "9.1.0"
     unist-util-remove "2.0.0"
@@ -1675,65 +1686,80 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@^6.0.0-alpha.9":
-  version "6.0.0-alpha.10"
-  resolved "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.0.0-alpha.10.tgz#000908bbe91e5cbfb9eaa6443f736e04a81fa733"
-  integrity sha512-iZjLH4J0WYlgq9BUs7kQAJTQv0qfkr7+LRq39GEGOVvw7fmEZ6nhTaagXFgOSPziavNoGjg/iy4Nb6SPaPtPIA==
+"@patternfly/patternfly@6.0.0-alpha.117":
+  version "6.0.0-alpha.117"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.117.tgz#ae62a787f99085acfecb4422fd1c08cace2fd23a"
+  integrity sha512-AqN09ur+jQXqtu7mf1UD7YmFa9fsbeb3tuyMwxut7P9QW4dvdTkHhFC9zv5eaJ5v7M03vvKKtxteVwPLaDn2zA==
 
-"@patternfly/react-code-editor@^6.0.0-alpha.1":
-  version "6.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.0.0-alpha.1.tgz#523aebb729ac10bcd6daca291983e363ea428e36"
-  integrity sha512-LrAHUL3HExSGQ1/cr5phWOGNQypM05gXQWx2h/+skDe4yNh90+E1Gkuni6A1rhF7MZqugQV54lSszIYRz5gDGQ==
+"@patternfly/react-code-editor@6.0.0-alpha.50":
+  version "6.0.0-alpha.50"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-6.0.0-alpha.50.tgz#10a0d0fb306355f70fe94695c4ff8631b805a19d"
+  integrity sha512-oNUOc2t//9MoipPXsrc9FxkaV+7VMdcKUMzgnS7kDpT8srRw8JLhvEScfKtyVpLBQQGaZPujkB/R6XSrlLzFqw==
   dependencies:
-    "@patternfly/react-core" "^6.0.0-alpha.1"
-    "@patternfly/react-icons" "^6.0.0-alpha.1"
-    "@patternfly/react-styles" "^6.0.0-alpha.1"
+    "@monaco-editor/react" "^4.6.0"
+    "@patternfly/react-core" "^6.0.0-alpha.50"
+    "@patternfly/react-icons" "^6.0.0-alpha.19"
+    "@patternfly/react-styles" "^6.0.0-alpha.19"
     react-dropzone "14.2.3"
     tslib "^2.5.0"
 
-"@patternfly/react-core@^6.0.0-alpha.1":
-  version "6.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0-alpha.1.tgz#f980c54db22cf42f6592754427a80ce6478a9b5a"
-  integrity sha512-ht8voYusmtMmAx96DY7NekhszWb8PqMl5Chw+sPBIItRqDbJDQRYXr2JamPhqyVfdmMJ61Jk6d85CumJ/C3wuw==
+"@patternfly/react-core@6.0.0-alpha.50", "@patternfly/react-core@^6.0.0-alpha.50":
+  version "6.0.0-alpha.50"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-6.0.0-alpha.50.tgz#982d773240e7adf969c9d53f0bf49c3ed25c550f"
+  integrity sha512-RIO5g0s/i5lAjkjp0eaOdqhefKzppWeAl7M/+dGkHjsoNUG0xbKigzpy3kHYHphbAA1O9vCKYfoEPlcTB0Svvg==
   dependencies:
-    "@patternfly/react-icons" "^6.0.0-alpha.1"
-    "@patternfly/react-styles" "^6.0.0-alpha.1"
-    "@patternfly/react-tokens" "^6.0.0-alpha.1"
+    "@patternfly/react-icons" "^6.0.0-alpha.19"
+    "@patternfly/react-styles" "^6.0.0-alpha.19"
+    "@patternfly/react-tokens" "^6.0.0-alpha.19"
     focus-trap "7.5.2"
     react-dropzone "^14.2.3"
     tslib "^2.5.0"
 
-"@patternfly/react-icons@^6.0.0-alpha.1":
-  version "6.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0-alpha.1.tgz#2ba63c24e6217a126b8dd9f7f3f8b23dc720c8e9"
-  integrity sha512-G7ewsy+eQSZGsi5i5Wg3zhwdnFS1S7so5qgaAslbId9yZwiJFnNL6s1c6bOkKwzRhIT6gNRL9YL77iswn7us6g==
+"@patternfly/react-icons@^6.0.0-alpha.19":
+  version "6.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-6.0.0-alpha.19.tgz#885e45fceac78a8d7269094e15c78394cd21b1dd"
+  integrity sha512-glp38ag1FVaAm1OtzAJYtbDw207xACqvTvUmWlESh2pEJ8FP7jr7vsxP+2LLue5Ag3b/J9JrrEl8ubQqZrpWug==
 
-"@patternfly/react-styles@^6.0.0-alpha.1":
-  version "6.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0-alpha.1.tgz#37b93c184d5d024b38b709afd107adb103568546"
-  integrity sha512-P5a/LYZkU+GkezhzXQaxRlCzgLCfvJNVAMOYq3m0FD51j4AxwlCkYeqnDxA+YFRMk+DSb8Pp1fXslmwRrFT83Q==
+"@patternfly/react-styles@6.0.0-alpha.19", "@patternfly/react-styles@^6.0.0-alpha.19":
+  version "6.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-6.0.0-alpha.19.tgz#4708b71889c25c7a87ba20878a601c8ab4c2426e"
+  integrity sha512-Qpa1nbPPvB0HoFWEfWMnG41lWmI0tV0c48QSpF01jDwUU6idqMlRjnW1O9E69CKP6C+8MQj2RxFSu8QOMhAi0A==
 
-"@patternfly/react-table@^6.0.0-alpha.1":
-  version "6.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.0.0-alpha.1.tgz#b8e407054c2ed3d628715ae368f896720f7d9254"
-  integrity sha512-0ThHk3wrLjDVSv4FZn4GhE+IDhnN92zhSZw/TM4Vsx67V3WrkBys5Iyg518BgohP19Z7D+Dp1V2F5ewJUEsRIQ==
+"@patternfly/react-table@6.0.0-alpha.50":
+  version "6.0.0-alpha.50"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-6.0.0-alpha.50.tgz#01b855a4ad596efda4fa40c7b91b09b7d8cbc84f"
+  integrity sha512-N6SoKVSi3LY/07vEKln3cqC2AwA3Hr13VUdXsDGLFYnbTtE32Eh5K6p9gLXejgDj9JQQ2uktaplHXIYtdh94qw==
   dependencies:
-    "@patternfly/react-core" "^6.0.0-alpha.1"
-    "@patternfly/react-icons" "^6.0.0-alpha.1"
-    "@patternfly/react-styles" "^6.0.0-alpha.1"
-    "@patternfly/react-tokens" "^6.0.0-alpha.1"
+    "@patternfly/react-core" "^6.0.0-alpha.50"
+    "@patternfly/react-icons" "^6.0.0-alpha.19"
+    "@patternfly/react-styles" "^6.0.0-alpha.19"
+    "@patternfly/react-tokens" "^6.0.0-alpha.19"
     lodash "^4.17.19"
     tslib "^2.5.0"
 
-"@patternfly/react-tokens@^6.0.0-alpha.1":
-  version "6.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0-alpha.1.tgz#20d67fd871dc3d4cbf26b9414c14d5eb15d5c6e7"
-  integrity sha512-b3P09skbUvKqgkmOvEwF31izWmkQ8+iUrJzQ6bt0L5D5OvUPMXcy+Ja3dOzaRG8+16S8lvN12h5Sh5RJLL6c1w==
+"@patternfly/react-tokens@^6.0.0-alpha.19":
+  version "6.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-6.0.0-alpha.19.tgz#dea91288e11e633dbff9251fa440519736ec785d"
+  integrity sha512-qxFPXdFWg7eq67XFoKVtpSGANd9HgnUA+mPJI1IRmHxhZmKbth0Ym3q6I745ratlGdrlpjg9YnRXmyOe8xPwpw==
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
   resolved "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
+
+"@puppeteer/browsers@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-0.5.0.tgz#1a1ee454b84a986b937ca2d93146f25a3fe8b670"
+  integrity sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==
+  dependencies:
+    debug "4.3.4"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    yargs "17.7.1"
 
 "@reach/router@npm:@gatsbyjs/reach-router@1.3.9":
   version "1.3.9"
@@ -2812,6 +2838,11 @@ axios@^0.24.0:
   dependencies:
     follow-redirects "^1.14.4"
 
+b4a@^1.6.4:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.6.tgz#a4cc349a3851987c3c4ac2d7785c18744f6da9ba"
+  integrity sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==
+
 babel-jest@^29.2.2:
   version "29.2.2"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-29.2.2.tgz"
@@ -2928,6 +2959,32 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+bare-events@^2.0.0, bare-events@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.2.2.tgz#a98a41841f98b2efe7ecc5c5468814469b018078"
+  integrity sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==
+
+bare-fs@^2.1.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-2.2.3.tgz#34f8b81b8c79de7ef043383c05e57d4a10392a68"
+  integrity sha512-amG72llr9pstfXOBOHve1WjiuKKAMnebcmMbPWDZ7BCevAoJLpugjuAPRsDINEyjT0a6tbaVx3DctkXIRbLuJw==
+  dependencies:
+    bare-events "^2.0.0"
+    bare-path "^2.0.0"
+    streamx "^2.13.0"
+
+bare-os@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-2.2.1.tgz#c94a258c7a408ca6766399e44675136c0964913d"
+  integrity sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==
+
+bare-path@^2.0.0, bare-path@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-2.1.1.tgz#111db5bf2db0aed40081aa4ba38b8dfc2bb782eb"
+  integrity sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==
+  dependencies:
+    bare-os "^2.1.0"
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -3375,6 +3432,13 @@ chromedriver@^101.0.0:
     proxy-from-env "^1.1.0"
     tcp-port-used "^1.0.1"
 
+chromium-bidi@0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.7.tgz#4c022c2b0fb1d1c9b571fadf373042160e71d236"
+  integrity sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==
+  dependencies:
+    mitt "3.0.0"
+
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz"
@@ -3760,7 +3824,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@^8.0.0:
+cosmiconfig@8.1.3, cosmiconfig@^8.0.0:
   version "8.1.3"
   resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz"
   integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
@@ -4090,10 +4154,15 @@ detab@2.0.3:
   dependencies:
     repeat-string "^1.5.4"
 
-detect-libc@^2.0.0, detect-libc@^2.0.1:
+detect-libc@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz"
   integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
+
+detect-libc@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
+  integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -4109,6 +4178,11 @@ devtools-protocol@0.0.1001819:
   version "0.0.1001819"
   resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz"
   integrity sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ==
+
+devtools-protocol@0.0.1107588:
+  version "0.0.1107588"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz#f8cac707840b97cc30b029359341bcbbb0ad8ffa"
+  integrity sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==
 
 diff-sequences@^29.2.0:
   version "29.2.0"
@@ -4898,6 +4972,11 @@ fast-diff@^1.1.2:
   resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-fifo@^1.1.0, fast-fifo@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
+
 fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz"
@@ -5348,16 +5427,15 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@8.0.3, glob@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+glob@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.0.0.tgz#8940d5f3225ca022931bf129cae13fc5f284aab7"
+  integrity sha512-7rdoWzT8/4f1yEe/cMdBug2lmzmYMYU9h4RNNiavPHajhcxt7kkxrOvwSnIPkZMjLQb9BXv7nFoKmTnPPklMyA==
   dependencies:
     fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
+    minimatch "^7.3.0"
+    minipass "^4.2.4"
+    path-scurry "^1.5.0"
 
 glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
@@ -6969,15 +7047,6 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz"
-  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
-
 loader-utils@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz"
@@ -7050,6 +7119,11 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
+lru-cache@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
+  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
 lru-cache@^4.0.1, lru-cache@^4.1.1:
   version "4.1.5"
@@ -7284,10 +7358,17 @@ minimatch@3.1.2, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0:
+minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^7.3.0:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
+  integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -7295,6 +7376,16 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
+minipass@^4.2.4:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
+  integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
 
 mississippi@^1.2.0, mississippi@^1.3.0:
   version "1.3.1"
@@ -7328,6 +7419,11 @@ mississippi@^2.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mitt@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
+  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
+
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
@@ -7340,14 +7436,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-monaco-editor-webpack-plugin@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz"
-  integrity sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==
-  dependencies:
-    loader-utils "^2.0.2"
-
-monaco-editor@0.34.1, monaco-editor@^0.34.1:
+monaco-editor@^0.34.1:
   version "0.34.1"
   resolved "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz"
   integrity sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==
@@ -7414,6 +7503,11 @@ nanoid@^3.3.4:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
+nanoid@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
+  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
 napi-build-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz"
@@ -7454,10 +7548,10 @@ node-abi@^3.3.0:
   dependencies:
     semver "^7.3.5"
 
-node-addon-api@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz"
-  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
+node-addon-api@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
 node-dir@^0.1.10:
   version "0.1.17"
@@ -8008,6 +8102,14 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.5.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.2.tgz#8f6357eb1239d5fa1da8b9f70e9c080675458ba7"
+  integrity sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
@@ -8140,14 +8242,14 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@7.0.32:
-  version "7.0.32"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz"
-  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
+postcss@8.4.32:
+  version "8.4.32"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.32.tgz#1dac6ac51ab19adb21b8b34fd2d93a86440ef6c9"
+  integrity sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==
   dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
+    nanoid "^3.3.7"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 postcss@^7.0.32:
   version "7.0.39"
@@ -8166,10 +8268,10 @@ postcss@^8.4.19:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-prebuild-install@^7.1.0:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz"
-  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+prebuild-install@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.2.tgz#a5fd9986f5a6251fbc47e1e5c65de71e68c0a056"
+  integrity sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==
   dependencies:
     detect-libc "^2.0.0"
     expand-template "^2.0.3"
@@ -8369,23 +8471,34 @@ puppeteer-cluster@0.23.0, puppeteer-cluster@^0.23.0:
   dependencies:
     debug "^4.3.3"
 
-puppeteer@14.3.0:
-  version "14.3.0"
-  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-14.3.0.tgz"
-  integrity sha512-pDtg1+vyw1UPIhUjh2/VW1HUdQnaZJHfMacrJciR3AVm+PBiqdCEcFeFb3UJ/CDEQlHOClm3/WFa7IjY25zIGg==
+puppeteer-core@19.11.1:
+  version "19.11.1"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.11.1.tgz#4c63d7a0a6cd268ff054ebcac315b646eee32667"
+  integrity sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==
   dependencies:
+    "@puppeteer/browsers" "0.5.0"
+    chromium-bidi "0.4.7"
     cross-fetch "3.1.5"
     debug "4.3.4"
-    devtools-protocol "0.0.1001819"
+    devtools-protocol "0.0.1107588"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.1"
-    pkg-dir "4.2.0"
-    progress "2.0.3"
     proxy-from-env "1.1.0"
-    rimraf "3.0.2"
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
-    ws "8.7.0"
+    ws "8.13.0"
+
+puppeteer@19.11.1:
+  version "19.11.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-19.11.1.tgz#bb75d518e87b0b4f6ef9bad1ea7e9d1cdcd18a5d"
+  integrity sha512-39olGaX2djYUdhaQQHDZ0T0GwEp+5f9UB9HmEP0qHfdQHIq0xGQZuAZ5TLnJIc/88SrPLpEflPC+xUqOTv3c5g==
+  dependencies:
+    "@puppeteer/browsers" "0.5.0"
+    cosmiconfig "8.1.3"
+    https-proxy-agent "5.0.1"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    puppeteer-core "19.11.1"
 
 puppeteer@^14.2.0:
   version "14.4.1"
@@ -8428,6 +8541,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue-tick@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142"
+  integrity sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -8516,13 +8634,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-monaco-editor@^0.51.0:
-  version "0.51.0"
-  resolved "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.51.0.tgz"
-  integrity sha512-6jx1V8p6gHVKJHFaTvicOtmlhFjOJhekobeNd92ZAo7F5UvAin1cF7bxWLCKgtxClYZ7CB3Ar284Kpbhj22FpQ==
-  dependencies:
-    prop-types "^15.8.1"
 
 react-ssr-prepass@1.5.0:
   version "1.5.0"
@@ -9068,6 +9179,13 @@ semver@^7.0.0, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.4:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.npmjs.org/send/-/send-0.18.0.tgz"
@@ -9170,18 +9288,18 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-sharp@0.30.6:
-  version "0.30.6"
-  resolved "https://registry.npmjs.org/sharp/-/sharp-0.30.6.tgz"
-  integrity sha512-lSdVxFxcndzcXggDrak6ozdGJgmIgES9YVZWtAFrwi+a/H5vModaf51TghBtMPw+71sLxUsTy2j+aB7qLIODQg==
+sharp@0.32.6:
+  version "0.32.6"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
+  integrity sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==
   dependencies:
     color "^4.2.3"
-    detect-libc "^2.0.1"
-    node-addon-api "^5.0.0"
-    prebuild-install "^7.1.0"
-    semver "^7.3.7"
+    detect-libc "^2.0.2"
+    node-addon-api "^6.1.0"
+    prebuild-install "^7.1.1"
+    semver "^7.5.4"
     simple-get "^4.0.1"
-    tar-fs "^2.1.1"
+    tar-fs "^3.0.4"
     tunnel-agent "^0.6.0"
 
 shebang-command@^1.2.0:
@@ -9442,6 +9560,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
+
 state-toggle@^1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz"
@@ -9469,6 +9592,16 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+streamx@^2.13.0, streamx@^2.15.0:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.16.1.tgz#2b311bd34832f08aa6bb4d6a80297c9caef89614"
+  integrity sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==
+  dependencies:
+    fast-fifo "^1.1.0"
+    queue-tick "^1.0.1"
+  optionalDependencies:
+    bare-events "^2.2.0"
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -9688,7 +9821,7 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar-fs@2.1.1, tar-fs@^2.0.0, tar-fs@^2.1.1:
+tar-fs@2.1.1, tar-fs@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz"
   integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
@@ -9707,6 +9840,17 @@ tar-fs@^1.15.3:
     mkdirp "^0.5.1"
     pump "^1.0.0"
     tar-stream "^1.1.2"
+
+tar-fs@^3.0.4:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.5.tgz#f954d77767e4e6edf973384e1eb95f8f81d64ed9"
+  integrity sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==
+  dependencies:
+    pump "^3.0.0"
+    tar-stream "^3.1.5"
+  optionalDependencies:
+    bare-fs "^2.1.1"
+    bare-path "^2.1.0"
 
 tar-stream@^1.1.2, tar-stream@^1.5.4:
   version "1.6.2"
@@ -9731,6 +9875,15 @@ tar-stream@^2.1.4:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+tar-stream@^3.1.5:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.7.tgz#24b3fb5eabada19fe7338ed6d26e5f7c482e792b"
+  integrity sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==
+  dependencies:
+    b4a "^1.6.4"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
 
 tcp-port-used@^1.0.1:
   version "1.0.2"
@@ -9980,12 +10133,11 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc@0.22.X:
-  version "0.22.18"
-  resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz"
-  integrity sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==
+typedoc@0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.0.tgz#dfb61f455d0111c206573de9bd48fd25b620d958"
+  integrity sha512-pcVvGbxRJDPuXKt7VV9gGMhR36kJc4IlQOnLAqfPQWujzHM9C4hW7gLjfpbXJXuwXkJehuFhPMOinga8mYFcjA==
   dependencies:
-    glob "^8.0.3"
     lunr "^2.3.9"
     marked "^4.0.16"
     minimatch "^5.1.0"
@@ -10763,6 +10915,11 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
+ws@8.13.0, ws@^8.13.0:
+  version "8.13.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz"
+  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+
 ws@8.7.0:
   version "8.7.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz"
@@ -10772,11 +10929,6 @@ ws@^7.3.1:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
-
-ws@^8.13.0:
-  version "8.13.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
 ws@^8.9.0:
   version "8.10.0"
@@ -10863,10 +11015,23 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.0.0, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@17.7.1:
+  version "17.7.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
+  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^13.3.0:
   version "13.3.2"


### PR DESCRIPTION
Closes #46.

- Updates to latest v6 alpha versions
- Fixes EmptyState structure change - as there was no header text, body text was pulled up into the title
- Updates usages of v5 to v6 classes (`pf-v6-c-console__xterm` doesn't seem to exist, did we have a v5 for this or was it always just a placeholder? @mcoker)
- Updates build commands to include watch
- Updates snapshots