### PR TITLE
Added wsProtocols prop to VncConsole

### DIFF
--- a/packages/module/src/components/VncConsole/VncConsole.tsx
+++ b/packages/module/src/components/VncConsole/VncConsole.tsx
@@ -48,6 +48,8 @@ export interface VncConsoleProps extends React.HTMLProps<HTMLDivElement> {
   credentials?: object;
   /** A DOMString specifying the ID to provide to any VNC repeater encountered */
   repeaterID?: string;
+  /** An Array of DOMStrings specifying the sub-protocols to use in the WebSocket connection */
+  wsProtocols?: string[];
   /** log-level for noVNC */
   vncLogging?: 'error' | 'warn' | 'none' | 'debug' | 'info';
   consoleContainerId?: string;
@@ -88,6 +90,7 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
   shared = false,
   credentials,
   repeaterID = '',
+  wsProtocols = [],
   vncLogging = 'warn',
   consoleContainerId,
   additionalButtons = [] as React.ReactNode[],
@@ -157,7 +160,8 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
     const options = {
       repeaterID,
       shared,
-      credentials
+      credentials,
+      wsProtocols
     };
     rfb.current = new RFB(novncElem.current, url, options);
     addEventListeners();
@@ -180,7 +184,8 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
     rfb,
     repeaterID,
     shared,
-    credentials
+    credentials,
+    wsProtocols
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Hello,

I've added the prop wsProtocols to the VncConsole component, this array of strings allows for a specific sub-protocol in the websocket connection.

This is already part of the version of noVNC included in react-console, this can also be found in the noVNC API documentation: https://novnc.com/noVNC/docs/API.html

Since there are no unit tests that cover this part, I've just rebuild it and tested it locally, and for me it works as expected.

I didn't change the documentation part, since the prop 'credentials' is also missing from the documentation and I'm not sure if the documentation is still generated from there. If it is, and it needs to be added, I'll do so, always easier to add then to remove.

-Wouter