### PR TITLE
chore: add PR preview deployment to surge

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,67 @@
+name: pr-preview
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-permissions:
+    uses: patternfly/.github/.github/workflows/check-team-membership.yml@main
+    secrets: inherit
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: check-permissions
+    if: needs.check-permissions.outputs.allowed == 'true'
+    env:
+      SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+      GH_PR_TOKEN: ${{ secrets.GH_PR_TOKEN }}
+      GH_PR_NUM: ${{ needs.check-permissions.outputs.pr-number }}
+    steps:
+      - uses: actions/checkout@v4
+      # Checkout the PR branch
+      - run: |
+          git fetch origin pull/$GH_PR_NUM/head:tmp
+          git checkout tmp
+      - run: |
+          git rev-parse origin/main
+          git rev-parse HEAD
+          git rev-parse origin/main..HEAD
+          git log origin/main..HEAD --format="%b"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: corepack enable
+      - uses: actions/cache@v4
+        id: yarn-cache
+        name: Cache yarn deps
+        with:
+          path: |
+            node_modules
+            **/node_modules
+          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - run: yarn install --immutable
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+      - run: yarn build
+        name: Build
+      - uses: actions/cache@v4
+        id: docs-cache
+        name: Load webpack cache
+        with:
+          path: '.cache'
+          key: ${{ runner.os }}-v4-${{ hashFiles('yarn.lock') }}
+      - run: yarn build:docs
+        name: Build docs
+      - name: Upload docs
+        uses: patternfly/.github/.github/actions/surge-preview@main
+        if: always()
+        with:
+          folder: packages/module/public
+      - run: yarn serve:docs & yarn test:a11y
+        name: a11y tests
+      - name: Upload a11y report
+        uses: patternfly/.github/.github/actions/surge-preview@main
+        if: always()
+        with:
+          folder: packages/module/coverage


### PR DESCRIPTION
Add pr-preview workflow that deploys docs to surge.sh for PR review. Uses shared team membership check from patternfly/.github to gate access to org secrets, and shared composite action for surge upload.