### PR TITLE
Add PF team issue labeling workflow

### DIFF
--- a/.github/workflows/label-pf-team-issue.yml
+++ b/.github/workflows/label-pf-team-issue.yml
@@ -1,0 +1,9 @@
+name: Label PF Team issues
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label:
+    uses: patternfly/.github/.github/workflows/add-pf-team-label-workflow.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add `.github/workflows/label-pf-team-issue.yml` to call the org-level reusable workflow that labels newly opened issues for PF team triage
- confirm the Surge preview workflow already uses the org-level team membership gate (`check-team-membership.yml`) and requires permission before deploy
- no legacy replacement issue workflows (`add-new-issues-to-project.yml` or `on_create_issue.yml`) were present in this repo

## Test plan
- [x] Validate workflow file syntax and structure
- [x] Verify `.github/workflows/pr-preview.yml` includes `pull_request_target` and `issue_comment` triggers
- [x] Verify preview job uses `needs: check-permissions` and `if: needs.check-permissions.outputs.allowed == 'true'`

Made with [Cursor](https://cursor.com)